### PR TITLE
[Cthulhu] Fix print messages from Cthulhu

### DIFF
--- a/logging/include/logging/LogChannel.h
+++ b/logging/include/logging/LogChannel.h
@@ -21,7 +21,7 @@ void log(const char* channel, const char* levelName, ::arvr::logging::Level leve
 
   char* const out = ::fmt::format_to_n(buffer, kLogCapacity, std::forward<Args>(args)...).out;
   int lineLength = out - buffer;
-  std::string line(out, out + lineLength);
+  std::string line(buffer, out + lineLength);
 
   stubLog("[{}][{}] {}", channel, levelName, line);
 }


### PR DESCRIPTION
Fixes a bug where errors and warnings printed
by Cthulhu come out mostly garbled.

## Description

This fixes garbled log prints from Cthulhu

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Overloaded Cthulhu buffers and observed that useful log messages are now printed.