### PR TITLE
Add an example for adding HDF5 logging to a graph

### DIFF
--- a/labgraph/examples/graph_w_logging.py
+++ b/labgraph/examples/graph_w_logging.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+
+import random
+import time
+from typing import Dict, Tuple
+
+import labgraph as lg
+
+# Note: Message has to be defined outside of the `__main__` module
+from .random_float_message import RandomFloatMessage
+
+
+class RandomFloatGenerator(lg.Node):
+    """
+    Generates messages with random float data
+    """
+
+    OUTPUT = lg.Topic(RandomFloatMessage)
+
+    @lg.publisher(OUTPUT)
+    async def output(self) -> lg.AsyncPublisher:
+        for _ in range(10):
+            yield self.OUTPUT, RandomFloatMessage(
+                timestamp=time.time(), data=random.random()
+            )
+        raise lg.NormalTermination()
+
+
+class Demo(lg.Graph):
+    """
+    A simple graph showing how we can log data from named topics.
+    - Logs to an h5 file in the current directory.
+    """
+
+    GENERATOR: RandomFloatGenerator
+
+    def process_modules(self) -> Tuple[lg.Module, ...]:
+        return (self.GENERATOR,)
+
+    def logging(self) -> Dict[str, lg.Topic]:
+        return {"random_data": self.GENERATOR.OUTPUT}
+
+
+if __name__ == "__main__":
+    graph = Demo()
+    options = lg.RunnerOptions(
+        logger_config=lg.LoggerConfig(
+            output_directory="./",
+            recording_name="graph_w_logging",
+        ),
+    )
+    runner = lg.ParallelRunner(graph=graph, options=options)
+    runner.run()

--- a/labgraph/examples/random_float_message.py
+++ b/labgraph/examples/random_float_message.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+
+import labgraph as lg
+
+
+class RandomFloatMessage(lg.Message):
+    timestamp: float
+    data: float


### PR DESCRIPTION
## Description
The process for enabling HDF5 logging involves a few steps.
- This PR adds an example for reference.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing
- [x] Run the example graph `python -m labgraph.examples.graph_w_logging`
- Verified that a HDF5 file named `graph_w_logging.h5` is created in the current directory.

## Checklist:
- Have you added tests that prove your fix is effective or that this feature works?
   - N/A, this is an example only and will be run to understand behavior; No unit tests required
- [x] New and existing unit tests pass locally with these changes?
- [x] Has code been commented, particularly in hard-to-understand areas?
- Have you made corresponding changes to the documentation?
   - N/A, this example is intended to be documentation
