### PR TITLE
[labgraph_protocol] Add option for fullscreen; Fix examples

### DIFF
--- a/extensions/labgraph_protocol/labgraph_protocol/examples/__main__.py
+++ b/extensions/labgraph_protocol/labgraph_protocol/examples/__main__.py
@@ -9,14 +9,19 @@ from labgraph_protocol.protocol_node import (
     ProtocolNode,
     ProtocolNodeConfig,
 )
-from labgraph_protocol.qt_node import QtNode, QtNodeConfig
+from labgraph_protocol.qt_node import (
+    FULLSCREEN,
+    QtNode,
+    QtNodeConfig,
+    WINDOW_SIZE_T,
+)
 
 PROTOCOL_MODULE = "labgraph_protocol.examples.{0}"
 
 
 class UIGraphConfig(lg.Config):
     protocol_name: str
-    window_size: typing.Tuple[int, int]
+    window_size: WINDOW_SIZE_T
 
 
 class UIGraph(lg.Graph):
@@ -51,10 +56,12 @@ class UIGraph(lg.Graph):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("protocol_name")
+    parser.add_argument("--fullscreen", action="store_true")
     args = parser.parse_args()
+    window_size = FULLSCREEN if args.fullscreen else (1280, 720)
     graph = UIGraph()
     graph.configure(
-        UIGraphConfig(protocol_name=args.protocol_name, window_size=(1280, 720))
+        UIGraphConfig(protocol_name=args.protocol_name, window_size=window_size)
     )
     runner = lg.ParallelRunner(graph=graph)
     runner.run()

--- a/extensions/labgraph_protocol/labgraph_protocol/qt_widgets.py
+++ b/extensions/labgraph_protocol/labgraph_protocol/qt_widgets.py
@@ -7,7 +7,7 @@ from PyQt5 import QtCore, QtGui, QtMultimedia, QtMultimediaWidgets, QtWidgets
 
 
 # Main window
-class MainWindow(QtWidgets.QWidget):
+class MainWindow(QtWidgets.QGraphicsView):
     def __init__(
         self, keypress_callbacks: typing.Dict[int, typing.Callable[..., typing.Any]]
     ) -> None:


### PR DESCRIPTION
## Description
Currently the examples in the labgraph_protocol extension don't run (window does not open and process hangs indefinitely).
This change fixes that by removing the extra parent widget and making the graphicsview the primary widget for the UI.

Also adds the ability to run an experiment in fullscreen via configuration.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing
Run examples from README:

`python -m extensions.labgraph_protocol.labgraph_protocol.examples PROTOCOL_NAME`

PROTOCOL_NAME can be any of:
- `audio_player`
- `display_image`
- `labels_buttons`
- `random_targets`
- `text_box_w_feedback`
- `video_player`

## Checklist:
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
