### PR TITLE
markdown syntax highlighting

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -17,7 +17,7 @@ In this overview we will use a toy example of a simple visualization. The exampl
 
 A **message** is a piece of data with a consistent structure. For example:
 
-```
+```python
 import numpy as np
 import labgraph.v1 as lg
 
@@ -34,7 +34,7 @@ This should look familiar if you are familiar with [dataclasses](https://docs.py
 
 To create a message, we simply create an instance of the `RandomMessage` class:
 
-```
+```python
 import time
 random_message = RandomMessage(
     timestamp=time.time(), data=np.random.rand(100)
@@ -43,13 +43,13 @@ random_message = RandomMessage(
 ```
 Suppose we were running an experiment where someone presses a button, and we wanted to include the state of the button with every frame. We could just add a `button_pressed` field to `RandomMessage`, but this would couple `RandomMessage` with that experiment and make reusing it with other experiments harder. Instead, we can **compose message types** via class inheritance (in the same way that the `dataclasses` module allows):
 
-```
+```python
 class CustomMessage(RandomMessage):
   button_pressed: bool
 ```
 Then `CustomMessage` retains all the fields of `RandomMessage`, and we can instantiate it like so:
 
-```
+```python
 custom_message = CustomMessage(
   timestamp=time.time(),
   data=np.random.rand(100),
@@ -74,7 +74,7 @@ A **node** is a class that describes a self-contained algorithm that operates on
 
 Nodes describe their algorithms using methods that are marked with special LabGraph decorators. Here is an example of a node that takes a rolling average of some data:
 
-```
+```python
 class RollingState(lg.State):
     messages: List[RandomMessage] = field(default_factory=list)
 
@@ -121,7 +121,7 @@ A **group** is a container that includes some functionality that can be reused m
 
 Suppose we wanted a way to quickly package together a data source and a transformation of that data. Here is a `Generator` node, as well as a group that packages it with `RollingAverager` above:
 
-```
+```python
 class GeneratorConfig(lg.Config):
     sample_rate: float
     num_features: int
@@ -177,7 +177,7 @@ Now we can use `AveragedNoise` as if it were a node – it is a self-contained m
 
 A **graph** is a complete set of topics and nodes that describes a functioning system. It is actually a group, but it is assumed to be the outermost container for the description of a system. Suppose we want to display a live visualization using our group from earlier. We can define a graph as follows:
 
-```
+```python
 class Demo(lg.Graph):
     AVERAGED_NOISE: AveragedNoise
     PLOT: Plot
@@ -204,7 +204,7 @@ class Demo(lg.Graph):
 
 Then we can run the graph using the `lg.run()` tool:
 
-```
+```python
 if __name__ == "__main__":
   lg.run(Demo)
 ```

--- a/docs/cpp-interop.md
+++ b/docs/cpp-interop.md
@@ -6,7 +6,7 @@ Sometimes, Python just isn't fast enough to be able to process real-time signals
 
 LabGraph comes with a `labgraph_cpp` library which allows us to define nodes directly in C++. Then, with the help of [pybind11](https://github.com/pybind/pybind11), we can embed that node in a LabGraph graph just as we would a Python node.
 
-```
+```c++
 // MyCPPSource.h
 #pragma once
 #include <labgraph/Node.h>
@@ -21,7 +21,7 @@ class MyCPPSource : public labgraph::Node {
 ```
 
 
-```
+```c++
 // MyCPPSource.cpp
 #include "MyCPPSource.h"
 #include "TestSample.h"
@@ -46,7 +46,7 @@ In the header and implementation above, we are defining `MyCPPSource`, which is 
 
 
 
-```
+```c++
 #include <labgraph/bindings.h>
 #include <pybind11/pybind11.h>
 #include "MyCPPSource.h"
@@ -70,7 +70,7 @@ Finally, we can use `MyCPPSource` in a LabGraph graph:
 
 
 
-```
+```python
 from MyCPPNodes import MyCPPSource
 class MyGraph(df.Graph):
   CPP_SOURCE: MyCPPSource

--- a/docs/cthulhu.md
+++ b/docs/cthulhu.md
@@ -30,7 +30,7 @@ A sample of a stream has 4 components:
 
 A user can define a sample format by inheriting from cthulhu::AutoStreamSample:
 
-```
+```c++
 class ImageData : public AutoStreamSample {
   using T = ImageData;
 
@@ -59,7 +59,7 @@ class ImageData : public AutoStreamSample {
 
 If a stream has no Content Block, it is called a "Basic Stream." And your journey ends here. Put this in a header, and call the basic registration function from the corresponding cpp source file:
 
-```
+```c++
 CTHULHU_REGISTER_BASIC_STREAM_TYPE(Image, cthulhu::ImageData);
 ```
 
@@ -73,7 +73,7 @@ If your stream includes a Content Block, it must also provide a Configuration wh
 
 Here is an example:
 
-```
+```c++
 enum class PixelFormat : uint32_t { INVALID = 0, MONO_8 = 1, MONO_10 = 2, YUY2 = 3, COUNT };
 
 class ImageFormat : public AutoStreamConfig {
@@ -107,7 +107,7 @@ class ImageFormat : public AutoStreamConfig {
 ```
 
 This stream can then be registered as an ordinary stream type:
-```
+```c++
 CTHULHU_REGISTER_STREAM_TYPE(Image, cthulhu::ImageData, cthulhu::ImageFormat);
 ```
 
@@ -123,7 +123,7 @@ Nodes are a logical unit of compute within the pipeline which receives N data st
 
 Here's an example of the most basic pub/sub behavior using a "Basic" stream type with sample type BasicSample:
 
-```
+```c++
 cthulhu::Context myContext("my_context");
 
 std::function<void(const BasicSample&)> cb =
@@ -141,7 +141,7 @@ But what if we had a heavy consuming function that needed its own thread or woul
 
 For usage of only single input or single output Nodes and basic stream types, this API looks a lot like basic pub/sub. Next, let's explore how we use an ordinary stream that uses both Config and Samples:
 
-```
+```c++
 // Subscribers must now specify two callbacks, one for sample and one for config
 // The config callback returns bool. With
 std::function<void(const cthulhu::ImageData&)> cb =
@@ -176,7 +176,7 @@ Calls to publish() and configure() are not thread safe. Thus, you should only pu
 
 So far, we've only explored single input and single output Nodes. Next, let's look at a Transformer with both an input and an output:
 
-```
+```c++
 std::function<void(const cthulhu::ImageData&, cthulhu::ImageData&)> cb =
     [](const cthulhu::ImageData& image, cthulhu::ImageData& imageOut) -> void {};
 std::function<bool(const cthulhu::ImageFormat&, cthulhu::ImageFormat&)> configCb =
@@ -197,7 +197,7 @@ Similar to Subscriber, this can be given TransformerOptions optionally to specif
 
 Finally, the most complex case of multi-input, multi-output, here is an example:
 
-```
+```c++
 std::function<void(const std::vector<cthulhu::ImageData>&, std::vector<cthulhu::ImageData>&)> cb =
     [](
         const std::vector<cthulhu::ImageData>& imagesIn,
@@ -219,11 +219,11 @@ Underneath the hood, Cthulhu is creating Producers and Consumers for each of the
 ## Clock
 
 Cthulhu also provides a clock interface, useful for system simulation. A user should query time through cthulhu:
-```
+```c++
 auto time = cthulhu::clock()->getTime();
 ```
 By default, this will just return wall time. However, a single context name can be given clock authority to control time. This should be whichever context is being used to control the flow of data via Publishers.
-```
+```c++
 int main() {
   // Declare use of simulated time, with clock_owner as the context
   cthulhu::ClockAuthority fac(true, "clock_owner");

--- a/docs/lifecycles-and-configuration.md
+++ b/docs/lifecycles-and-configuration.md
@@ -12,7 +12,7 @@ A node, group, or graph (a module) goes through the following steps in its lifet
 
 LabGraph provides a way to concisely specify configuration that is given to a graph and forwarded to its descendant nodes. We start by defining a configuration type:
 
-```
+```python
 class MyNodeConfig(df.Config):
   num_trials: int
   participant_name: str
@@ -23,7 +23,7 @@ class MyNodeConfig(df.Config):
 
 We specify the configuration for a `Node`, `Group`, or `Graph` by giving it a `config` type annotation:
 
-```
+```python
 class MyNode(df.Node):
   config: MyNodeConfig
 
@@ -31,7 +31,7 @@ class MyNode(df.Node):
 ```
 Then we can configure it by calling `configure()` on it. We configure a node or group in the `setup()` method of its containing group:
 
-```
+```python
 class MyGroupConfig(df.Config):
   ...
 
@@ -47,17 +47,17 @@ class MyGroup(df.Config):
 ```
 The exception to this is graphs, which we can construct and configure directly:
 
-```
+```python
 my_graph = MyGraph()
 my_graph.configure(MyGraphConfig(...))
 ```
 Rather than hard-coding the top-level configuration like this, though, we can automatically build the configuration from from command-line arguments like so:
 
-```
+```python
 my_config = MyGraphConfig.fromargs()
 ```
 The `df.run` function actually gets configuration using `fromargs()`, so we can also just run a graph using command-line arguments like so:
 
-```
+```python
 df.run(MyGraph)
 ```

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -13,7 +13,7 @@ LabGraph Messages are how we define data types for use in our computational grap
 
 Here is a simple example of connectability:
 
-```
+```python
 class MyMessage1(df.Message):
   field1: int
   field2: df.NumpyType(shape=(100, 100))

--- a/docs/websockets-api-errors.md
+++ b/docs/websockets-api-errors.md
@@ -1,13 +1,13 @@
 # WebSockets API Error Codes
 
 **`ErrorEvent`**
-```
+```json
 {
   "api_version": 0.1,
   "api_event": {
     "request_id": [REQUEST_ID],
     "error_event": {
-      "error_code": [ERROR-CODE]
+      "error_code": [ERROR-CODE],
       "desc": [DESCRIPTION-OF-ERROR]
     }
   }

--- a/docs/websockets-api.md
+++ b/docs/websockets-api.md
@@ -20,7 +20,7 @@ To **connect** an application to the API layer, your application should open a W
 To open an input or output stream using **API-Requests**, applications should send a `StartStreamRequest` message, which specifies the name of the stream to be opened. Stream names are specified entirely in the config, and any LabGraph user may write transformers that take or output any API stream with any name, as long as that name is unique in the config.
 
 **`StartStreamRequest`**
-```
+```json
 {
    "api_version": "0.1",
    "api_request": {
@@ -37,12 +37,12 @@ To open an input or output stream using **API-Requests**, applications should se
 * request_id: (integer) allows LabGraph to match the response to the request to the request itself. That is, the request_id in the in the response for any request will match the request_id sent in the request. Should be unique within a Session, but this is not enforced. Applies for all request types.
 * stream_id: (string) uniquely identifies the stream within a Session and is set by the application.
 * app_id: (string) optional, used in Terminal output of LabGraph to provide more information to users. Should identify the application making the request and is set by the application.
-* StreamName: (string) This could either be the namespaced input or output stram name.
+* StreamName: (string) This could either be the namespaced input or output stream name.
 
 On receipt of a `StartStreamRequest`, LabGraph will send a `StartStreamEvent` back to the application. If there is an error, LabGraph will send back an `ErrorEvent` (API Errors) message. The format of a `StartStreamEvent` is the following:
 
 **`StartStreamEvent`**
-```
+```json
 {
    "api_version": 0.1,
    "api_event": {
@@ -58,7 +58,7 @@ On receipt of a `StartStreamRequest`, LabGraph will send a `StartStreamEvent` ba
 To end a stream, an application should either send an `EndStreamRequest` or terminate the WebSocket connection. The format of an `EndStreamRequest` is the following:
 
 **`EndStreamRequest`**
-```
+```json
 {
    "api_version": 0.1,
    "api_request": {
@@ -75,7 +75,7 @@ To end a stream, an application should either send an `EndStreamRequest` or term
 On receipt of an EndStreamRequest, LabGraph will send an EndStreamEvent back to the application. If there is an error, LabGraph will send back an ErrorEvent (Errors: Websocket APIs) message. The format of an EndStreamEvent is the following:
 
 **`EndStreamEvent`**
-```
+```json
 {
    "api_version": 0.1,
    "api_event": {
@@ -91,7 +91,7 @@ On receipt of an EndStreamRequest, LabGraph will send an EndStreamEvent back to 
 LabGraph will send an error message to your application under a variety of circumstances. Error codes are listed and described here: API Error Codes (websockets-api-errors.md)
 
 **`ErrorEvent`**
-```
+```json
 {
    "api_version": 0.1,
    "api_event": {
@@ -108,7 +108,7 @@ LabGraph will send an error message to your application under a variety of circu
 Input/Output stream messages should be sent in the following format, where individual samples must be JSON parsable.
 
 **Input/Output `StreamBatch`**
-```
+```json
 {
   "api_version": 0.1,
   "stream_batch": {
@@ -123,14 +123,14 @@ Input/Output stream messages should be sent in the following format, where indiv
 
 ## Example Usage
 Step 1: Run WebSocket Server
-```
+```shell
 python -m labgraph.websockets.ws_server.tests.test_server_local
 ```
 Step 2: Run WebSocket Client
-```
+```shell
 python -m labgraph.websockets.ws_client.tests.test_ws_node_client
 ```
 Note: In case webSocket server has not been terminated properly, terminate the process using:
-```
+```shell
 sudo pkill -9 python
 ```


### PR DESCRIPTION
## Description

Adds syntax highlighting for code snippets in markdown files, such as:
````
```python                 # <--- language tag here
def fn():
    ...
```
````

In `websockets-api.md` and `websockets-api-errors.md`, the placeholder JSON fields like `StreamName` look a bit odd with syntax highlighting.
One option would be replacing them with a string in carets, like `"<StreamName>"` instead of `StreamName`, such as:
```json
{
   "api_version": "0.1",
   "api_request": {
     "request_id": "<RequestId>",
     "start_stream_request": {
       "stream_id": "<StreamId>",
       "app_id": "<ApplicationName>",
        "<StreamName>": {}
     }
   }
}
```

## Type of change

Cosmetic change.

## Feature/Issue validation/testing

No changed functionality.