### PR TITLE
Serial Port Support

### DIFF
--- a/labgraph/devices/protocols/serial/README.md
+++ b/labgraph/devices/protocols/serial/README.md
@@ -1,0 +1,20 @@
+The way I'm able to test it right now is the following:
+
+First, I make sure to create a virtual port like `pty`
+
+```python
+import os
+import pty
+import serial
+
+parent, child = pty.openpty() # ex. parent is 13, child is 14
+s_name = os.ttyname(child) #  ex. `/dev/pts/5`
+
+ser = serial.Serial(s_name) # opens a serial port
+ser.write("wow".encode("utf-8")) # writes b'wow' to the port
+os.read(parent, 1000) # reads b'wow' from the port
+```
+
+Having setup the `/dev/pts/5` port, I can run `python -m labgraph.devices.protocols.serial.tests.test_serial_poller`.
+
+It will write `'hello'.encode('utf-8')` to the terminal. So having run `os.read(parent, 1000)` again, I get `b'wowhello'`.s

--- a/labgraph/devices/protocols/serial/__init__.py
+++ b/labgraph/devices/protocols/serial/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+
+from .serial_message import SERIALMessage
+from .serial_poller_node import SERIALPollerNode

--- a/labgraph/devices/protocols/serial/serial_message.py
+++ b/labgraph/devices/protocols/serial/serial_message.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+
+from labgraph.messages import Message
+
+
+class SERIALMessage(Message):
+    """
+    A message representing data that was/will be communicated to Serial.
+    """
+
+    data: bytes

--- a/labgraph/devices/protocols/serial/serial_poller_node.py
+++ b/labgraph/devices/protocols/serial/serial_poller_node.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+
+from labgraph.util.logger import get_logger
+import serial
+
+
+logger = get_logger(__name__)
+
+class SERIALPollerNode():
+    """
+    Represents a node in the graph which polls data from PySerial.
+    """
+    
+    def setup(self) -> None:
+        self.serial = serial.Serial("/dev/pts/5")
+        self.name = self.serial.name
+    def cleanup(self) -> None:
+        self.serial.close()
+    def write(self) -> None:
+        self.serial.write('hello'.encode('utf-8'))
+    def read(self) -> bytes:
+        return self.serial.readline()

--- a/labgraph/devices/protocols/serial/tests/__init__.py
+++ b/labgraph/devices/protocols/serial/tests/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.

--- a/labgraph/devices/protocols/serial/tests/test_serial_poller.py
+++ b/labgraph/devices/protocols/serial/tests/test_serial_poller.py
@@ -1,0 +1,11 @@
+from labgraph.devices.protocols.serial.serial_poller_node import SERIALPollerNode
+
+serial_poller = SERIALPollerNode()
+
+serial_poller.setup()
+
+serial_poller.write()
+
+serial_poller.read()
+
+serial_poller.cleanup()


### PR DESCRIPTION
## Description

Trying to adapt PySerial as a way to integrative devices to LabGraph.

Fixes #42 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Run test `python -m labgraph.devices.protocols.serial.tests.test_serial_poller`.

It requires to have a pseudo-teletype that must be specified in `serial_poller_node.py` for now.

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
