### PR TITLE
Update Numpy to >= 1.21

### DIFF
--- a/extensions/labgraph_viz/setup.py
+++ b/extensions/labgraph_viz/setup.py
@@ -14,7 +14,7 @@ setup(
         "dataclasses==0.6",
         "labgraph>=1.0.2",
         "matplotlib==3.1.1",
-        "numpy==1.21.0",
+        "numpy==1.19.5",
         "PyQt5-sip==12.8.1",
         "pyqtgraph==0.11.1",
     ],

--- a/extensions/labgraph_viz/setup.py
+++ b/extensions/labgraph_viz/setup.py
@@ -14,7 +14,7 @@ setup(
         "dataclasses==0.6",
         "labgraph>=1.0.2",
         "matplotlib==3.1.1",
-        "numpy==1.21",
+        "numpy==1.21.0",
         "PyQt5-sip==12.8.1",
         "pyqtgraph==0.11.1",
     ],

--- a/extensions/labgraph_viz/setup.py
+++ b/extensions/labgraph_viz/setup.py
@@ -14,7 +14,7 @@ setup(
         "dataclasses==0.6",
         "labgraph>=1.0.2",
         "matplotlib==3.1.1",
-        "numpy==1.16.4",
+        "numpy==1.21",
         "PyQt5-sip==12.8.1",
         "pyqtgraph==0.11.1",
     ],

--- a/extensions/yaml_support/setup.py
+++ b/extensions/yaml_support/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "labgraph>=1.0.2",
-        "numpy>=1.21",
+        "numpy>=1.21.0",
         "PyYAML==6.0",
         "StrEnum==0.4.7",
         "typed_ast>=1.4.3",

--- a/extensions/yaml_support/setup.py
+++ b/extensions/yaml_support/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "labgraph>=1.0.2",
-        "numpy>=1.21.0",
+        "numpy>=1.19.5",
         "PyYAML==6.0",
         "StrEnum==0.4.7",
         "typed_ast>=1.4.3",

--- a/extensions/yaml_support/setup.py
+++ b/extensions/yaml_support/setup.py
@@ -11,7 +11,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "labgraph>=1.0.2",
-        "numpy>=1.16.4",
+        "numpy>=1.21",
         "PyYAML==6.0",
         "StrEnum==0.4.7",
         "typed_ast>=1.4.3",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "h5py>=3.3.0",
         "matplotlib>=3.1.2",
         "mypy>=0.910",
-        "numpy>=1.21.0",
+        "numpy>=1.19.5",
         "psutil>=5.6.7",
         "pytest>=3.10.1",
         "pytest_mock>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "h5py>=3.3.0",
         "matplotlib>=3.1.2",
         "mypy>=0.910",
-        "numpy>=1.19.5",
+        "numpy>=1.21",
         "psutil>=5.6.7",
         "pytest>=3.10.1",
         "pytest_mock>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "h5py>=3.3.0",
         "matplotlib>=3.1.2",
         "mypy>=0.910",
-        "numpy>=1.21",
+        "numpy>=1.21.0",
         "psutil>=5.6.7",
         "pytest>=3.10.1",
         "pytest_mock>=2.0.0",

--- a/setup_py36.py
+++ b/setup_py36.py
@@ -38,7 +38,7 @@ setup(
         "kiwisolver==1.3.2",
         "matplotlib==3.1.1",
         "mypy==0.782",
-        "numpy==1.21",
+        "numpy==1.21.0",
         "psutil==5.6.7",
         "pylsl==1.15.0",
         "pytest==3.10.1",

--- a/setup_py36.py
+++ b/setup_py36.py
@@ -38,7 +38,7 @@ setup(
         "kiwisolver==1.3.2",
         "matplotlib==3.1.1",
         "mypy==0.782",
-        "numpy==1.16.4",
+        "numpy==1.21",
         "psutil==5.6.7",
         "pylsl==1.15.0",
         "pytest==3.10.1",

--- a/setup_py36.py
+++ b/setup_py36.py
@@ -38,7 +38,7 @@ setup(
         "kiwisolver==1.3.2",
         "matplotlib==3.1.1",
         "mypy==0.782",
-        "numpy==1.21.0",
+        "numpy==1.19.5",
         "psutil==5.6.7",
         "pylsl==1.15.0",
         "pytest==3.10.1",


### PR DESCRIPTION
Package name: numpy
Affected versions: >= 1.9.0, < 1.21
Fixed in version: 1.21
Severity: MODERATE

Identifier(s):
GHSA-6p56-wp2h-9hxr
CVE-2021-33430

Reference(s):
https://nvd.nist.gov/vuln/detail/CVE-2021-33430
https://github.com/numpy/numpy/issues/18939
https://github.com/numpy/numpy/commit/ae317fd9ff3e79c0eac357d723bfc29cbd625f2e
https://github.com/advisories/GHSA-6p56-wp2h-9hxr
