### PR TITLE
Fixed Apache Ant version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN yum install -y python2 python36 python36-devel wget java-1.8.0-openjdk \
 
 # Install Ant
 WORKDIR "/tmp"
-RUN wget https://downloads.apache.org/ant/binaries/apache-ant-1.10.11-bin.zip
-RUN unzip apache-ant-1.10.11-bin.zip \
-    && mv apache-ant-1.10.11/ /opt/ant \
+RUN wget https://downloads.apache.org/ant/binaries/apache-ant-1.10.12-bin.zip
+RUN unzip apache-ant-1.10.12-bin.zip \
+    && mv apache-ant-1.10.12/ /opt/ant \
     && ln -s /opt/ant/bin/ant /usr/bin/ant
 
 # Download Buck


### PR DESCRIPTION
## Description

The `main.yml` workflow kept failing on me, so I figured it would be useful to fix the Apache Ant version issue that was making the docker build fail.

You can find the successful build logs here: https://github.com/dtemir/labgraph/runs/6014180685?check_suite_focus=true
You can find the unsuccessful build logs here: https://github.com/facebookresearch/labgraph/runs/5803725955?check_suite_focus=true

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Testing is done by running the `main.yml` in GitHub Actions

## Checklist:

- [X] New and existing unit tests pass locally with these changes?
