### PR TITLE
pre-commit hook for black and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+      language_version: python3.8
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+    - id: flake8
+      args: ['--config=docs/tools/codetools/.flake8']

--- a/docs/tools/codetools/README.md
+++ b/docs/tools/codetools/README.md
@@ -3,12 +3,45 @@
 **Install Flake8**:
 https://flake8.pycqa.org/en/latest/
 
-```
+```bash
 python -m pip install flake8
 ```
 
 **Use Flake8 to check your code before submission**:
 
-```
+```bash
 flake8 --config .flake8 [file_name]
 ```
+
+# Use pre-commit hooks for code consistency
+
+**Install pre-commit**:
+https://pre-commit.com/
+
+```bash
+pip install pre-commit
+```
+
+**Install the git hooks script**:
+
+```bash
+pre-commit install
+```
+
+It uses a file called `.pre-commit-config.yaml` to create a Git hook `.git/hooks/pre-commit`
+
+**Commit your changes**:
+
+```bash
+git commit -m "Your Message"
+```
+
+and it will automatically run `black` and `flake8` on the files you changed
+
+```bash
+git commit -m "Added pre-commit hook documentation"
+black................................................(no files to check)Skipped
+Flake8...............................................(no files to check)Skipped
+[pre-commit-hooks 1d3d92f] Added pre-commit hook documentation
+ 1 file changed, 27 insertions(+), 2 deletions(-)
+ ```


### PR DESCRIPTION
## Description

I think it would be a good idea to standardize the code contributed to LabGraph by having contributors use [`pre-commit`](https://pre-commit.com/) hook that will automatically run [`black`](https://github.com/psf/black) and [`flake8`](https://github.com/PyCQA/flake8) when the user makes a commit.

That way as users keep committing changes, the new code will automatically follow good standards.

Fixes #74 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] New and existing unit tests pass locally with these changes?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [X] Have you made corresponding changes to the documentation?
