### PR TITLE
Labgraph pilot

### DIFF
--- a/extensions/labgraph_pilot/labgraph_pilot/description_to_code.py
+++ b/extensions/labgraph_pilot/labgraph_pilot/description_to_code.py
@@ -1,0 +1,38 @@
+import requests
+import json
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class DescriptionToCode:
+    """
+    A class that send the request to OpenAI API with a prompt to get back the code
+    """
+    def __init__(self):
+        self.prompt = "Provide well-engineered code for"
+        self.model = "text-davinci-003"
+        self.max_tokens = 500 # maximum length for the response from the API request
+        self.temperature = 0
+        self.api_key = os.getenv('OPENAI_API_KEY')
+
+    def get_code_from_description(self, api_name):
+        url = "https://api.openai.com/v1/completions"
+
+        payload = json.dumps({
+        "model": self.model,
+        "prompt": self.prompt + api_name,
+        "max_tokens": 500, # handcrafted parameter
+        "temperature": 0
+        })
+
+        headers = {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + self.api_key
+        }
+
+        response = requests.request("POST", url, headers=headers, data=payload)
+        json_data = json.loads(response.text)
+        generated_code = json_data['choices'][0]['text']
+
+        return generated_code

--- a/extensions/labgraph_pilot/labgraph_pilot/description_to_code.py
+++ b/extensions/labgraph_pilot/labgraph_pilot/description_to_code.py
@@ -5,6 +5,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+from keyword_generation import KeywordGeneration
+
 class DescriptionToCode:
     """
     A class that send the request to OpenAI API with a prompt to get back the code
@@ -36,3 +38,23 @@ class DescriptionToCode:
         generated_code = json_data['choices'][0]['text']
 
         return generated_code
+
+    '''
+    Main function of generating the code for each API name and save it to a local file
+    '''
+    def get_code(self):
+        keywordGeneration = KeywordGeneration()
+        apis = keywordGeneration.extract_keywords()
+
+        with open('output.txt', 'w') as file:
+            code_blocks = []
+
+            for api in apis:
+                code_block = self.get_code_from_description(api)
+                code_blocks.append(code_block)
+
+            file.writelines("% s\n" % code_block for code_block in code_blocks)
+
+# create a test object to run the get_code function
+test = DescriptionToCode()
+test.get_code()

--- a/extensions/labgraph_pilot/labgraph_pilot/keyword_generation.py
+++ b/extensions/labgraph_pilot/labgraph_pilot/keyword_generation.py
@@ -1,0 +1,32 @@
+# generate the list names from predefined urls
+# sicpy, numpy, sklearn
+import requests
+from bs4 import BeautifulSoup
+
+class KeywordGeneration:
+
+    '''
+    A class that generates lists of APIs for different categories 
+    (hardware devices, signal processing, etc.)
+    '''   
+    def __init__(self) -> None:
+        self.predefined_urls = ['https://docs.scipy.org/doc/scipy/reference/signal.html',
+                                # 'https://numpy.org/doc/stable/reference/routines.ma.html',
+                                # 'https://numpy.org/doc/stable/reference/routines.math.html',
+                                # 'https://numpy.org/doc/1.24/reference/routines.html',
+                                # 'https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing',
+                                ]
+        self.signal_processing_apis = []
+        self.numpy_apis = []
+        self.sklearn_apis = []
+    def get_html_from_urls(self):
+        for url in self.predefined_urls:
+            page = requests.get(url)
+            soup = BeautifulSoup(page.text, features="lxml")
+
+            keywords_elements = soup.find_all("tr")
+            for keyword in keywords_elements:
+                # TODO: extract the 'keyword'
+
+test = KeywordGeneration()
+test.get_html_from_urls()

--- a/extensions/labgraph_pilot/labgraph_pilot/keyword_generation.py
+++ b/extensions/labgraph_pilot/labgraph_pilot/keyword_generation.py
@@ -22,7 +22,7 @@ class KeywordGeneration:
     This function gets the html content from the predefined urls using requests library. Then use BeautifulSoup to 
     extract the needed keywords
     '''
-    
+
     def extract_keywords(self):
         
         for url in self.predefined_urls:
@@ -37,7 +37,6 @@ class KeywordGeneration:
                         for key, value in tag.attrs.items():
                             if key == 'title':
                                 self.keywords.append(value)
-        print(self.keywords)
-
+        return self.keywords
 test = KeywordGeneration()
 test.extract_keywords()

--- a/extensions/labgraph_pilot/labgraph_pilot/keyword_generation.py
+++ b/extensions/labgraph_pilot/labgraph_pilot/keyword_generation.py
@@ -11,22 +11,33 @@ class KeywordGeneration:
     '''   
     def __init__(self) -> None:
         self.predefined_urls = ['https://docs.scipy.org/doc/scipy/reference/signal.html',
-                                # 'https://numpy.org/doc/stable/reference/routines.ma.html',
-                                # 'https://numpy.org/doc/stable/reference/routines.math.html',
-                                # 'https://numpy.org/doc/1.24/reference/routines.html',
-                                # 'https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing',
+                                'https://numpy.org/doc/stable/reference/routines.ma.html',
+                                'https://numpy.org/doc/stable/reference/routines.math.html',
+                                'https://numpy.org/doc/1.24/reference/routines.html',
+                                'https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing',
                                 ]
-        self.signal_processing_apis = []
-        self.numpy_apis = []
-        self.sklearn_apis = []
-    def get_html_from_urls(self):
+        self.keywords = []
+
+    '''
+    This function gets the html content from the predefined urls using requests library. Then use BeautifulSoup to 
+    extract the needed keywords
+    '''
+    
+    def extract_keywords(self):
+        
         for url in self.predefined_urls:
             page = requests.get(url)
             soup = BeautifulSoup(page.text, features="lxml")
 
             keywords_elements = soup.find_all("tr")
-            for keyword in keywords_elements:
-                # TODO: extract the 'keyword'
+            
+            for element in keywords_elements:
+                for tag in element.recursiveChildGenerator():
+                    if hasattr(tag, 'attrs'):
+                        for key, value in tag.attrs.items():
+                            if key == 'title':
+                                self.keywords.append(value)
+        print(self.keywords)
 
 test = KeywordGeneration()
-test.get_html_from_urls()
+test.extract_keywords()

--- a/extensions/labgraph_pilot/labgraph_pilot/setup.py
+++ b/extensions/labgraph_pilot/labgraph_pilot/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+
+from setuptools import find_packages, setup
+
+
+setup(
+    name="labgraph_pilot",
+    version="1.0.0",
+    description="",
+    packages=find_packages(),
+    python_requires=">=3.6, <3.7",
+    install_requires=[
+        "dataclasses==0.6",
+        "labgraph>=1.0.2",
+        "matplotlib==3.1.1",
+        "numpy==1.16.4",
+        "PyQt5-sip==12.8.1",
+        "pyqtgraph==0.11.1",
+    ],
+)


### PR DESCRIPTION
## Description

This feature is data generation for training purposes. 
Scrape API keywords from several predefined urls and pass these keywords to OpenAI API to get the generated code for that each keyword.

The generated code blocks will be saved to a local file. Just specify the directory you want to save the results, and you can go that place to look at the generated code blocks.

Because using OpenAI API requires a API_key, we store it in a .env file (make sure to have .env package installed by `pip install dotenv`).

Fixes #97 

## Feature/Issue validation/testing

To validate if the code works, you can follow these steps:
1. To test if we have successfully extract the keywords, open the `keyword_generation.py` file, create a constant for KeywordGeneration class and run the `extract_keywords` function, you could look at the output in the terminal and a list of expected keywords will be printed. For example, initiate the instance as `test = KeywordGeneration()` and run `test.extract_keywords()`, we should see the output in the terminal as shown below:

![image](https://user-images.githubusercontent.com/63086003/221331351-cb4366ac-82ac-4db3-901b-3fa1783b873b.png)


2. i) To test if the configuration to access the OpenAI API has been successful, open the `decription_to_code.py` file, create a constant for DescriptionToCode class and run the `get_code_from_description` function with an arbitrary API keyword as a parameter. For example, initiate the instance as `test = DescriptionToCode()` and run `test.get_code_from_description('scipy.signal.convolve'), we should get back the expected code block in the terminal as shown below:

![image](https://user-images.githubusercontent.com/63086003/221331606-e58b7c7a-405c-4184-8dad-e9346ba33bb1.png)

ii) To generate the code blocks for every single API keyword and save it a local file, run `test.get_code()` and open the 'output.txt' file to see the result as shown below:
![image](https://user-images.githubusercontent.com/63086003/221331897-d5d7ca4f-b0b5-451d-92f8-add53eeb06c1.png)

![image](https://user-images.githubusercontent.com/63086003/221331924-928eb5c3-843c-4365-bee1-4b938c5fb859.png)

