### PR TITLE
Code to Node Conversion

### DIFF
--- a/extensions/lgpilot/codeToNode.py
+++ b/extensions/lgpilot/codeToNode.py
@@ -1,0 +1,39 @@
+import sys
+
+def create_setup(writer):
+    writer.write(f"\nclass FilterNode(lg.Node):\n")
+    writer.write("\tINPUT = lg.Topic(InputMessage)\n\tOUTPUT = lg.Topic(OutputMessage)\n")
+    writer.write("\tdef setup(self):\n\t\tself.func = filter_function\n")
+    return
+
+def create_filter(writer):
+    writer.write("\t@lg.subscriber(INPUT)\n\t@lg.publisher(OUTPUT)\n")
+    writer.write("\n\tdef filter(self, message: MessageInput):\n")
+    writer.write("\t\ty = self.func(message.x)\n\t\tyield self.OUTPUT, y")
+
+
+def code_to_node(filename):
+    """ Take a python file <filename> containing a filter function and 
+    output a file named node.py containing labgraph node. 
+
+    """
+    with open(filename, 'r') as reader:
+        with open("node.py", 'w') as writer:
+            filter_function = False
+            filter_type = ""
+            for line in reader:
+                if "import" in line: # copy all import statements
+                    writer.write(line)
+                if "filter_function" in line: # copy the filter function 
+                    filter_function = True
+                if filter_function:
+                    writer.write(line)
+                if "return" in line: 
+                    filter_function = False
+                    create_setup(writer)
+                    create_filter(writer)
+                
+            
+                    
+if __name__ == "__main__":
+    code_to_node(sys.argv[1])

--- a/extensions/lgpilot/filters/IIR_filter.py
+++ b/extensions/lgpilot/filters/IIR_filter.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+def filter_function(x, a, b):
+    """  A function to apply an IRR filter to a signal.
+    Input is <x>, and filter parameters are <a> and <b>.
+    The output <y> is a signal that has been processed with the filter. 
+    """
+    z = np.zeros(max(len(b), len(a)))
+    y = np.zeros_like(x)
+    for n in range(len(x)):
+        y[n] = b[0] * x[n]
+        for m in range(1, len(b)):
+            if n-m >= 0:
+                y[n] += b[m] * x[n-m]
+        for m in range(1, len(a)):
+            if n-m >= 0:
+                y[n] -= a[m] * y[n-m]
+        z[0] = x[n]
+        z[1:] = z[:-1]
+    return y 

--- a/extensions/lgpilot/filters/butterworth_filter.py
+++ b/extensions/lgpilot/filters/butterworth_filter.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+def filter_function(x, cutoff_freq, sample_rate, order=4):
+    """
+    A function to apply a Butterworth filter to a signal.
+    
+    Args:
+        x (numpy.ndarray): The input signal to be filtered.
+        cutoff_freq (float): The cutoff frequency of the filter.
+        sample_rate (float): The sample rate of the signal.
+        order (int): The order of the filter. Defaults to 4.
+    
+    Returns:
+        numpy.ndarray: The filtered signal.
+    """
+    nyquist_freq = sample_rate / 2
+    normal_cutoff = cutoff_freq / nyquist_freq
+    b = np.zeros(order+1)
+    a = np.zeros(order+1)
+    
+    for i in range(order+1):
+        binomial_coefficient = 1
+        for j in range(order):
+            if j != i:
+                binomial_coefficient *= (normal_cutoff - np.exp(1j*np.pi*(j-i)/order)) / (1 - np.exp(1j*np.pi*(j-i)/order))
+        b[i] = np.real(binomial_coefficient)
+        a[i] = np.imag(binomial_coefficient)
+    
+    gain = 1 / np.abs(np.polyval(b, 1j*normal_cutoff) / np.polyval(a, 1j*normal_cutoff))
+    b *= gain
+
+    y = np.zeros_like(x)
+    
+    for i in range(len(x)):
+        y[i] = np.sum(b * x[max(0,i-len(b)+1):i+1]) - np.sum(a[1:] * x[max(0,i-len(a)):i])
+    
+    return y


### PR DESCRIPTION
## Description
The file codeToNode.py converts a signal filter function into a labgraph node. Some test filters have been included in the `filters/` folder. The assumption is that the input file contains python code containing a single filter function and the output will be a file containing a labgraph node. 

Fixes #(issue)
#96 
## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## Feature/Issue validation/testing
If we want to test out the conversion of Butterworth Filter as an example, run the following command:
`~/labgraph/extensions/lgpilot (issue-96) $ python3 codeToNode.py filters/butterworth_filter.py `

You should have an output file `lgpilot/node.py` containing the node conversion.

